### PR TITLE
feat: Create sms-notifier-prototype service

### DIFF
--- a/sms-notifier-prototype/README.md
+++ b/sms-notifier-prototype/README.md
@@ -1,0 +1,108 @@
+# SMS Notifier Prototype
+
+## Visão Geral
+
+O `sms-notifier-prototype` é um microsserviço em Clojure que faz parte do **Protótipo Integrado do Sistema de Notificação (SNCT)**.
+
+Seu propósito é validar o fluxo de notificação de ponta a ponta de forma simplificada. Ele opera da seguinte maneira:
+
+1.  **Consome dados** do serviço `notification-watcher`, que detecta mudanças de categoria em templates de mensagens.
+2.  **Busca informações de contato** de clientes a partir de uma fonte de dados mockada (variável de ambiente).
+3.  **Simula o envio de notificações** por SMS, imprimindo os detalhes da notificação no console.
+4.  Garante a **idempotência**, ou seja, que a mesma notificação não seja processada repetidamente, usando um cache em memória.
+
+Este serviço **não utiliza um banco de dados**. Todo o seu estado (contatos e cache de notificações enviadas) é gerenciado em memória.
+
+## Pré-requisitos
+
+*   Java (JDK 11 ou superior)
+*   [Leiningen](https://leiningen.org/)
+*   O serviço `notification-watcher` deve estar em execução.
+
+## Configuração
+
+O serviço é configurado através de variáveis de ambiente. Você pode exportá-las no seu terminal ou criar um arquivo `.env` na raiz do projeto e usar a biblioteca `environ`.
+
+### Variáveis de Ambiente
+
+*   `WATCHER_URL`
+    *   **Descrição:** A URL base onde o serviço `notification-watcher` está escutando.
+    *   **Obrigatório:** Não
+    *   **Padrão:** `http://localhost:8080`
+    *   **Exemplo:** `WATCHER_URL="http://127.0.0.1:8080"`
+
+*   `MOCK_CUSTOMER_DATA`
+    *   **Descrição:** Uma string contendo um objeto JSON que mapeia WABA IDs (WhatsApp Business Account IDs) para números de telefone de contato.
+    *   **Obrigatório:** Sim (para que as notificações sejam "enviadas")
+    *   **Formato:** String JSON com chaves sendo os WABA IDs e valores sendo os números de telefone.
+    *   **Exemplo:**
+        ```bash
+        MOCK_CUSTOMER_DATA='{"waba_id_1": "+5511999998888", "waba_id_2": "+5521888887777"}'
+        ```
+
+## Como Executar o Protótipo
+
+Para executar o protótipo completo, você precisará de dois terminais: um para o `notification-watcher` e outro para o `sms-notifier-prototype`.
+
+### Terminal 1: Executar o `notification-watcher`
+
+1.  **Navegue até o diretório** do `notification-watcher`:
+    ```sh
+    cd ../notification-watcher
+    ```
+
+2.  **Configure as variáveis de ambiente**. Para o protótipo, é recomendado usar o modo mock da Gupshup. Crie ou edite seu arquivo `.env` ou exporte as seguintes variáveis:
+    ```sh
+    export GUPSHUP_MOCK_MODE="true"
+    export MOCK_CUSTOMER_MANAGER_WABA_IDS="waba_id_1,waba_id_2"
+    export PORT="8080"
+    ```
+    *Nota: Os `MOCK_CUSTOMER_MANAGER_WABA_IDS` devem corresponder às chaves no `MOCK_CUSTOMER_DATA` do `sms-notifier-prototype`.*
+
+3.  **Execute o serviço**:
+    ```sh
+    lein run
+    ```
+    O serviço irá iniciar e, após um breve atraso, começará a popular seus dados mockados. O endpoint `http://localhost:8080/changed-templates` estará ativo.
+
+### Terminal 2: Executar o `sms-notifier-prototype`
+
+1.  **Navegue até o diretório** deste projeto:
+    ```sh
+    cd ../sms-notifier-prototype
+    ```
+
+2.  **Configure as variáveis de ambiente**. Crie ou edite seu arquivo `.env` ou exporte as seguintes variáveis:
+    ```sh
+    export WATCHER_URL="http://localhost:8080"
+    export MOCK_CUSTOMER_DATA='{"waba_id_1": "+5511999998888", "waba_id_2": "+5521888887777"}'
+    ```
+
+3.  **Instale as dependências**:
+    ```sh
+    lein deps
+    ```
+
+4.  **Execute o serviço**:
+    ```sh
+    lein run
+    ```
+
+### O que Esperar
+
+*   No terminal do `sms-notifier-prototype`, você verá logs indicando que ele está consultando o `notification-watcher`.
+*   Quando o `notification-watcher` tiver dados de templates alterados, o `sms-notifier-prototype` irá recebê-los.
+*   Você verá no console do `sms-notifier-prototype` uma saída formatada que **simula o envio de um SMS**, mais ou menos assim:
+
+    ```
+    --------------------------------------------------
+    SIMULANDO ENVIO DE SMS
+    PARA: +5511999998888
+    MENSAGEM: Alerta de Mudança de Categoria de Template!
+      - WABA ID: waba_id_1
+      - Template: meu_template_de_teste (template_123)
+      - Categoria Anterior: MARKETING
+      - Nova Categoria: UTILITY
+    --------------------------------------------------
+    ```
+*   Nas consultas seguintes, se a mesma notificação for detectada, você verá uma mensagem indicando que ela já foi processada e será ignorada, validando a lógica de idempotência.

--- a/sms-notifier-prototype/project.clj
+++ b/sms-notifier-prototype/project.clj
@@ -1,0 +1,13 @@
+(defproject sms-notifier-prototype "0.1.0-SNAPSHOT"
+  :description "Prototype for the SMS Notifier service"
+  :url "http://example.com/FIXME"
+  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
+            :url "https://www.eclipse.org/legal/epl-2.0/"}
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [clj-http "3.12.3"]
+                 [cheshire "5.11.0"]
+                 [environ "1.2.0"]]
+  :main ^:skip-aot sms-notifier-prototype.core
+  :target-path "target/%s"
+  :profiles {:uberjar {:aot :all
+                       :jvm-opts ["-Dclojure.compiler.direct-linking=true"]}})

--- a/sms-notifier-prototype/src/sms_notifier_prototype/core.clj
+++ b/sms-notifier-prototype/src/sms_notifier_prototype/core.clj
@@ -1,0 +1,92 @@
+(ns sms-notifier-prototype.core
+  (:require [clj-http.client :as client]
+            [cheshire.core :as json]
+            [environ.core :refer [env]])
+  (:gen-class))
+
+;; Atom para garantir a idempotência. Armazenará chaves únicas para notificações já processadas.
+(def sent-notifications-cache (atom #{}))
+
+;; Atom para armazenar os dados de contato mockados.
+(def mock-customer-data (atom {}))
+
+(defn parse-customer-data
+  "Lê e parseia a string JSON da variável de ambiente MOCK_CUSTOMER_DATA."
+  []
+  (if-let [customer-data-json (env :mock-customer-data)]
+    (try
+      (let [parsed-data (json/parse-string customer-data-json true)]
+        (reset! mock-customer-data parsed-data)
+        (println "Dados de clientes mockados carregados com sucesso."))
+      (catch Exception e
+        (println (str "Erro ao parsear MOCK_CUSTOMER_DATA: " (.getMessage e)))))
+    (println "Aviso: Variável de ambiente MOCK_CUSTOMER_DATA não definida.")))
+
+(defn get-contact-phone
+  "Busca o telefone de contato para um WABA ID específico nos dados mockados."
+  [waba-id]
+  (get @mock-customer-data (keyword waba-id)))
+
+(defn process-notification
+  "Processa uma notificação, simula o envio e atualiza o cache de idempotência."
+  [template]
+  (let [waba-id (:wabaId template)
+        template-id (:id template)
+        new-category (:category template)
+        notification-key (str template-id "_" new-category)]
+
+    (if (@sent-notifications-cache notification-key)
+      (println (str "Notificação para " notification-key " já processada. Ignorando."))
+      (if-let [phone (get-contact-phone waba-id)]
+        (do
+          (println "--------------------------------------------------")
+          (println "SIMULANDO ENVIO DE SMS")
+          (println (str "PARA: " phone))
+          (println "MENSAGEM: Alerta de Mudança de Categoria de Template!")
+          (println (str "  - WABA ID: " waba-id))
+          (println (str "  - Template: " (:elementName template) " (" template-id ")"))
+          (println (str "  - Categoria Anterior: " (:oldCategory template)))
+          (println (str "  - Nova Categoria: " new-category))
+          (println "--------------------------------------------------")
+          (swap! sent-notifications-cache conj notification-key))
+        (println (str "Aviso: Telefone de contato não encontrado para o WABA ID: " waba-id))))))
+
+(defn fetch-and-process-templates
+  "Busca templates alterados do notification-watcher e inicia o processamento."
+  []
+  (let [watcher-url (env :watcher-url "http://localhost:8080")]
+    (println (str "Consultando " watcher-url "/changed-templates..."))
+    (try
+      (let [response (client/get (str watcher-url "/changed-templates")
+                                 {:as :json
+                                  :throw-exceptions false
+                                  :conn-timeout 5000
+                                  :socket-timeout 5000})
+            templates (get-in response [:body])]
+        (if (and (= (:status response) 200) (seq templates))
+          (do
+            (println (str "Recebidos " (count templates) " templates alterados."))
+            (doseq [template templates]
+              (process-notification template)))
+          (println "Nenhum template alterado encontrado ou erro na resposta.")))
+      (catch Exception e
+        (println (str "Erro ao conectar com o notification-watcher: " (.getMessage e)))))))
+
+(defn start-notifier-loop!
+  "Inicia o loop principal do serviço em uma thread separada."
+  []
+  (println "Iniciando o loop do SMS Notifier Prototype...")
+  (future
+    (loop []
+      (fetch-and-process-templates)
+      (Thread/sleep 60000) ; Espera 1 minuto
+      (recur))))
+
+(defn -main
+  "Ponto de entrada principal da aplicação."
+  [& args]
+  (println "======================================")
+  (println "  SMS Notifier Prototype v0.1.0")
+  (println "======================================")
+  (parse-customer-data)
+  (start-notifier-loop!))


### PR DESCRIPTION
This commit introduces the new `sms-notifier-prototype` service as outlined in the technical prototype report.

The service is a lightweight Clojure application designed to validate the end-to-end notification flow in a simplified manner. It connects to the existing `notification-watcher` service, consumes detected template changes, and simulates sending SMS notifications to the console.

Key features:
- Polls the `notification-watcher` for changed templates.
- Uses environment variables for configuration, including mock customer contact data.
- Implements in-memory idempotency to prevent duplicate notifications.
- Includes a detailed README.md with setup and execution instructions for the complete prototype.