### PR TITLE
feat: Prepare services for Render deploy

### DIFF
--- a/notification-watcher/DEPLOY.md
+++ b/notification-watcher/DEPLOY.md
@@ -1,0 +1,39 @@
+# Deploy no Render
+
+Este documento fornece as instruções para fazer o deploy do serviço `notification-watcher` na plataforma [Render](https://render.com/).
+
+## Tipo de Serviço
+
+O `notification-watcher` deve ser implantado como um **Web Service** no Render, pois ele precisa expor uma porta HTTP (`8080` por padrão) para que o `sms-notifier-prototype` possa se conectar a ele.
+
+## Instruções de Configuração
+
+1.  **Conecte seu repositório** Git ao Render.
+2.  Crie um novo **Web Service**.
+3.  Use as seguintes configurações durante a criação do serviço:
+
+    *   **Build Command**:
+        ```sh
+        ./build.sh
+        ```
+
+    *   **Start Command**:
+        ```sh
+        java -jar target/uberjar/notification-watcher-0.1.0-SNAPSHOT-standalone.jar
+        ```
+        *Nota: O nome do arquivo JAR pode variar. Verifique o nome exato no diretório `target/uberjar` após a primeira build.*
+
+4.  **Porta (Port)**:
+    *   O Render detectará automaticamente que o serviço está escutando na porta `8080`. Certifique-se de que a configuração de porta no Render corresponda à porta que o serviço usa (definida pela variável de ambiente `PORT` ou o padrão `8080`).
+
+5.  **Adicione as Variáveis de Ambiente** na aba "Environment" do seu serviço no Render:
+    *   **Para o protótipo**, use o modo mock para não depender de chaves de API reais:
+        *   `GUPSHUP_MOCK_MODE`:
+            *   **Valor:** `true`
+        *   `MOCK_CUSTOMER_MANAGER_WABA_IDS`:
+            *   **Valor:** `waba_id_1,waba_id_2` (ou os mesmos IDs que você configurou no `sms-notifier-prototype`).
+    *   **Para produção** (no futuro):
+        *   `GUPSHUP_TOKEN`: Seu token de API real da Gupshup.
+        *   `CUSTOMER_MANAGER_URL`: A URL do `customer-manager-service` quando ele for desenvolvido.
+
+Após salvar, o Render irá construir, implantar e iniciar o serviço. Ele receberá uma URL pública (ex: `notification-watcher.onrender.com`) que você deverá usar na configuração da variável de ambiente `WATCHER_URL` do serviço `sms-notifier-prototype`.

--- a/notification-watcher/build.sh
+++ b/notification-watcher/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Exit on error
+set -o errexit
+
+# Install dependencies
+lein deps
+
+# Compile into a single JAR
+lein uberjar

--- a/sms-notifier-prototype/README.md
+++ b/sms-notifier-prototype/README.md
@@ -106,3 +106,30 @@ Para executar o protótipo completo, você precisará de dois terminais: um para
     --------------------------------------------------
     ```
 *   Nas consultas seguintes, se a mesma notificação for detectada, você verá uma mensagem indicando que ela já foi processada e será ignorada, validando a lógica de idempotência.
+
+---
+
+## Deploy no Render
+
+Para fazer o deploy deste serviço no [Render](https://render.com/), siga os seguintes passos. Recomenda-se fazer o deploy deste serviço como um **Background Worker**.
+
+1.  **Conecte seu repositório** Git ao Render.
+2.  Crie um novo **Background Worker**.
+3.  Use as seguintes configurações durante a criação do serviço:
+
+    *   **Build Command**:
+        ```sh
+        ./build.sh
+        ```
+
+    *   **Start Command**:
+        ```sh
+        java -jar target/uberjar/sms-notifier-prototype-0.1.0-SNAPSHOT-standalone.jar
+        ```
+        *Nota: O nome do arquivo JAR pode variar. Verifique o nome exato no diretório `target/uberjar` após a primeira build.*
+
+4.  **Adicione as Variáveis de Ambiente** na aba "Environment" do seu serviço no Render:
+    *   `WATCHER_URL`: Aponte para a URL interna do seu serviço `notification-watcher` no Render (ex: `http://notification-watcher:8080` ou a URL `.onrender.com`).
+    *   `MOCK_CUSTOMER_DATA`: Cole a sua string JSON de contatos mockados.
+
+Após salvar, o Render irá construir e iniciar o serviço automaticamente. Você poderá ver os logs (incluindo as notificações simuladas) na aba "Logs" do serviço.

--- a/sms-notifier-prototype/build.sh
+++ b/sms-notifier-prototype/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Exit on error
+set -o errexit
+
+# Install dependencies
+lein deps
+
+# Compile into a single JAR
+lein uberjar


### PR DESCRIPTION
This commit adds the necessary configuration to deploy the `notification-watcher` and `sms-notifier-prototype` services to Render.

Changes include:
- Adding a `build.sh` script to both services to create an executable uberjar.
- Creating a `DEPLOY.md` for `notification-watcher` with specific instructions for deploying it as a Web Service on Render.
- Updating the `README.md` for `sms-notifier-prototype` with instructions for deploying it as a Background Worker on Render.

These changes ensure that both services can be easily built and deployed on the Render platform.