### PR TITLE
feat: Align services to use Docker for deploy

### DIFF
--- a/notification-watcher/DEPLOY.md
+++ b/notification-watcher/DEPLOY.md
@@ -1,39 +1,30 @@
-# Deploy no Render
+# Deploy no Render com Docker
 
-Este documento fornece as instruções para fazer o deploy do serviço `notification-watcher` na plataforma [Render](https://render.com/).
+Este documento fornece as instruções para fazer o deploy do serviço `notification-watcher` na plataforma [Render](https://render.com/), utilizando o `Dockerfile` presente no projeto.
 
 ## Tipo de Serviço
 
-O `notification-watcher` deve ser implantado como um **Web Service** no Render, pois ele precisa expor uma porta HTTP (`8080` por padrão) para que o `sms-notifier-prototype` possa se conectar a ele.
+O `notification-watcher` deve ser implantado como um **Web Service** no Render, pois ele precisa expor uma porta HTTP para que o `sms-notifier-prototype` possa se conectar a ele.
 
 ## Instruções de Configuração
 
 1.  **Conecte seu repositório** Git ao Render.
 2.  Crie um novo **Web Service**.
-3.  Use as seguintes configurações durante a criação do serviço:
-
-    *   **Build Command**:
-        ```sh
-        ./build.sh
-        ```
-
-    *   **Start Command**:
-        ```sh
-        java -jar target/uberjar/notification-watcher-0.1.0-SNAPSHOT-standalone.jar
-        ```
-        *Nota: O nome do arquivo JAR pode variar. Verifique o nome exato no diretório `target/uberjar` após a primeira build.*
+3.  Durante a criação, o Render irá detectar o `Dockerfile` no seu repositório. Selecione esta opção para o deploy. O Render se encarregará de construir a imagem Docker e executar o contêiner. Os comandos de build e de início já estão definidos no `Dockerfile`.
 
 4.  **Porta (Port)**:
-    *   O Render detectará automaticamente que o serviço está escutando na porta `8080`. Certifique-se de que a configuração de porta no Render corresponda à porta que o serviço usa (definida pela variável de ambiente `PORT` ou o padrão `8080`).
+    *   O `Dockerfile` expõe a porta `8080`. O Render detectará isso automaticamente. Certifique-se de que a configuração de porta no Render esteja definida como `8080`.
 
-5.  **Adicione as Variáveis de Ambiente** na aba "Environment" do seu serviço no Render:
+5.  **Adicione as Variáveis de Ambiente** na aba "Environment" do seu serviço no Render. Estas irão sobrescrever os valores `ENV` definidos no `Dockerfile`.
     *   **Para o protótipo**, use o modo mock para não depender de chaves de API reais:
         *   `GUPSHUP_MOCK_MODE`:
             *   **Valor:** `true`
         *   `MOCK_CUSTOMER_MANAGER_WABA_IDS`:
             *   **Valor:** `waba_id_1,waba_id_2` (ou os mesmos IDs que você configurou no `sms-notifier-prototype`).
+        *   `PORT`:
+            *   **Valor:** `8080` (O Render usa esta variável para rotear o tráfego, mesmo que o `Dockerfile` já exponha a porta).
     *   **Para produção** (no futuro):
         *   `GUPSHUP_TOKEN`: Seu token de API real da Gupshup.
         *   `CUSTOMER_MANAGER_URL`: A URL do `customer-manager-service` quando ele for desenvolvido.
 
-Após salvar, o Render irá construir, implantar e iniciar o serviço. Ele receberá uma URL pública (ex: `notification-watcher.onrender.com`) que você deverá usar na configuração da variável de ambiente `WATCHER_URL` do serviço `sms-notifier-prototype`.
+Após salvar, o Render irá construir a imagem Docker, implantar e iniciar o serviço. Ele receberá uma URL pública (ex: `notification-watcher.onrender.com`) que você deverá usar na configuração da variável de ambiente `WATCHER_URL` do serviço `sms-notifier-prototype`.

--- a/notification-watcher/build.sh
+++ b/notification-watcher/build.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Exit on error
-set -o errexit
-
-# Install dependencies
-lein deps
-
-# Compile into a single JAR
-lein uberjar

--- a/sms-notifier-prototype/Dockerfile
+++ b/sms-notifier-prototype/Dockerfile
@@ -1,0 +1,33 @@
+# Etapa 1: Build - Use a imagem oficial do Leiningen para compilar o projeto
+FROM clojure:lein-2.9.1 as builder
+
+# Defina o diretório de trabalho dentro do contêiner
+WORKDIR /app
+
+# Copie os arquivos de definição do projeto primeiro para aproveitar o cache do Docker
+COPY project.clj .
+
+# Baixe as dependências. Isso será cacheado se o project.clj não mudar.
+RUN lein deps
+
+# Copie o código-fonte da aplicação
+COPY src ./src
+
+# Compile a aplicação em um uberjar (JAR auto-suficiente)
+RUN lein uberjar
+
+# Etapa 2: Execução - Use uma imagem leve com apenas o Java Runtime Environment (JRE)
+FROM openjdk:11-jre-slim
+
+# Defina o diretório de trabalho
+WORKDIR /app
+
+# Copie o uberjar da etapa de build para a imagem final
+COPY --from=builder /app/target/uberjar/sms-notifier-prototype-0.1.0-SNAPSHOT-standalone.jar ./app.jar
+
+# Defina as variáveis de ambiente (serão substituídas pelas configurações do Render, se fornecidas)
+ENV WATCHER_URL="http://localhost:8080"
+ENV MOCK_CUSTOMER_DATA='{}'
+
+# Comando para executar a aplicação quando o contêiner iniciar
+CMD ["java", "-jar", "app.jar"]

--- a/sms-notifier-prototype/README.md
+++ b/sms-notifier-prototype/README.md
@@ -109,27 +109,16 @@ Para executar o protótipo completo, você precisará de dois terminais: um para
 
 ---
 
-## Deploy no Render
+## Deploy no Render com Docker
 
-Para fazer o deploy deste serviço no [Render](https://render.com/), siga os seguintes passos. Recomenda-se fazer o deploy deste serviço como um **Background Worker**.
+Para fazer o deploy deste serviço no [Render](https://render.com/), siga os seguintes passos. Recomenda-se fazer o deploy deste serviço como um **Background Worker**, pois ele não precisa expor uma porta pública.
 
 1.  **Conecte seu repositório** Git ao Render.
 2.  Crie um novo **Background Worker**.
-3.  Use as seguintes configurações durante a criação do serviço:
+3.  Durante a criação, Render irá detectar o `Dockerfile` no seu repositório. Selecione esta opção para o deploy. O Render não precisará de um "Build Command" ou "Start Command", pois eles já estão definidos dentro do `Dockerfile` (`lein uberjar` e `java -jar app.jar`).
 
-    *   **Build Command**:
-        ```sh
-        ./build.sh
-        ```
+4.  **Adicione as Variáveis de Ambiente** na aba "Environment" do seu serviço no Render. Estas irão sobrescrever os valores `ENV` definidos no `Dockerfile`.
+    *   `WATCHER_URL`: Aponte para a URL interna do seu serviço `notification-watcher` no Render (ex: `http://notification-watcher:8080` ou a URL `.onrender.com` fornecida pelo Render).
+    *   `MOCK_CUSTOMER_DATA`: Cole a sua string JSON de contatos mockados. Ex: `'{"waba_id_1": "+5511999998888"}'`.
 
-    *   **Start Command**:
-        ```sh
-        java -jar target/uberjar/sms-notifier-prototype-0.1.0-SNAPSHOT-standalone.jar
-        ```
-        *Nota: O nome do arquivo JAR pode variar. Verifique o nome exato no diretório `target/uberjar` após a primeira build.*
-
-4.  **Adicione as Variáveis de Ambiente** na aba "Environment" do seu serviço no Render:
-    *   `WATCHER_URL`: Aponte para a URL interna do seu serviço `notification-watcher` no Render (ex: `http://notification-watcher:8080` ou a URL `.onrender.com`).
-    *   `MOCK_CUSTOMER_DATA`: Cole a sua string JSON de contatos mockados.
-
-Após salvar, o Render irá construir e iniciar o serviço automaticamente. Você poderá ver os logs (incluindo as notificações simuladas) na aba "Logs" do serviço.
+Após salvar, o Render irá construir a imagem Docker a partir do seu `Dockerfile` e iniciar o contêiner. Você poderá ver os logs (incluindo as notificações simuladas) na aba "Logs" do serviço.

--- a/sms-notifier-prototype/build.sh
+++ b/sms-notifier-prototype/build.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Exit on error
-set -o errexit
-
-# Install dependencies
-lein deps
-
-# Compile into a single JAR
-lein uberjar


### PR DESCRIPTION
This commit refactors the deploy strategy to use Docker for both `notification-watcher` and `sms-notifier-prototype`, ensuring consistency across the project as you requested.

Changes:
- Adds a `Dockerfile` to `sms-notifier-prototype`, mirroring the multi-stage build pattern of the `notification-watcher`.
- Updates `README.md` and `DEPLOY.md` in both services with instructions for deploying to Render using Docker.
- Removes the now-obsolete `build.sh` scripts from both services.

This brings both services into alignment, using a standardized, container-based approach for deployment.