### PR TITLE
fix: Adapt sms-notifier-prototype for Render free tier

### DIFF
--- a/sms-notifier-prototype/Dockerfile
+++ b/sms-notifier-prototype/Dockerfile
@@ -28,6 +28,10 @@ COPY --from=builder /app/target/uberjar/sms-notifier-prototype-0.1.0-SNAPSHOT-st
 # Defina as variáveis de ambiente (serão substituídas pelas configurações do Render, se fornecidas)
 ENV WATCHER_URL="http://localhost:8080"
 ENV MOCK_CUSTOMER_DATA='{}'
+ENV PORT="8080"
+
+# Exponha a porta que o servidor web irá usar
+EXPOSE 8080
 
 # Comando para executar a aplicação quando o contêiner iniciar
 CMD ["java", "-jar", "app.jar"]

--- a/sms-notifier-prototype/README.md
+++ b/sms-notifier-prototype/README.md
@@ -111,14 +111,23 @@ Para executar o protótipo completo, você precisará de dois terminais: um para
 
 ## Deploy no Render com Docker
 
-Para fazer o deploy deste serviço no [Render](https://render.com/), siga os seguintes passos. Recomenda-se fazer o deploy deste serviço como um **Background Worker**, pois ele não precisa expor uma porta pública.
+Para fazer o deploy deste serviço no [Render](https://render.com/) no plano gratuito, ele deve ser configurado como um **Web Service**.
+
+O serviço foi adaptado para iniciar um servidor web mínimo para satisfazer os requisitos do Render, enquanto o processo principal de notificação continua rodando em background.
+
+### Instruções de Configuração
 
 1.  **Conecte seu repositório** Git ao Render.
-2.  Crie um novo **Background Worker**.
-3.  Durante a criação, Render irá detectar o `Dockerfile` no seu repositório. Selecione esta opção para o deploy. O Render não precisará de um "Build Command" ou "Start Command", pois eles já estão definidos dentro do `Dockerfile` (`lein uberjar` e `java -jar app.jar`).
+2.  Crie um novo **Web Service**.
+3.  Durante a criação, o Render irá detectar o `Dockerfile` no seu repositório. Selecione esta opção para o deploy. Os comandos de build e de início já estão definidos dentro do `Dockerfile`.
 
-4.  **Adicione as Variáveis de Ambiente** na aba "Environment" do seu serviço no Render. Estas irão sobrescrever os valores `ENV` definidos no `Dockerfile`.
-    *   `WATCHER_URL`: Aponte para a URL interna do seu serviço `notification-watcher` no Render (ex: `http://notification-watcher:8080` ou a URL `.onrender.com` fornecida pelo Render).
+4.  **Porta (Port)**:
+    *   O `Dockerfile` expõe a porta `8080`. O Render detectará isso automaticamente. Certifique-se de que a configuração de porta no Render esteja definida como `8080`.
+
+5.  **Adicione as Variáveis de Ambiente** na aba "Environment" do seu serviço no Render. Estas irão sobrescrever os valores `ENV` definidos no `Dockerfile`.
+    *   `WATCHER_URL`: Aponte para a URL pública do seu serviço `notification-watcher` no Render (ex: `https://notification-watcher.onrender.com`).
     *   `MOCK_CUSTOMER_DATA`: Cole a sua string JSON de contatos mockados. Ex: `'{"waba_id_1": "+5511999998888"}'`.
+    *   `PORT`:
+        *   **Valor:** `8080`
 
-Após salvar, o Render irá construir a imagem Docker a partir do seu `Dockerfile` e iniciar o contêiner. Você poderá ver os logs (incluindo as notificações simuladas) na aba "Logs" do serviço.
+Após salvar, o Render irá construir a imagem Docker, implantar e iniciar o serviço. A URL pública dele mostrará uma mensagem de status, e o worker de notificação estará ativo, com os logs visíveis na aba "Logs".

--- a/sms-notifier-prototype/project.clj
+++ b/sms-notifier-prototype/project.clj
@@ -6,7 +6,8 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [clj-http "3.12.3"]
                  [cheshire "5.11.0"]
-                 [environ "1.2.0"]]
+                 [environ "1.2.0"]
+                 [http-kit "2.5.3"]]
   :main ^:skip-aot sms-notifier-prototype.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all


### PR DESCRIPTION
This commit modifies the `sms-notifier-prototype` to allow it to be deployed as a Web Service on Render's free tier.

Changes:
- Adds the `http-kit` dependency.
- Updates `core.clj` to start a minimal web server in the main thread, satisfying Render's requirement for a Web Service to bind to a port. The notification polling loop continues to run in a background thread.
- Updates the `Dockerfile` to expose port 8080.
- Updates the `README.md` with new instructions for deploying the service as a Web Service on Render.

This ensures the entire prototype can be deployed without incurring costs on Render.