### PR TITLE
refactor: Rename sms-notifier-prototype to sms-notifier

### DIFF
--- a/sms-notifier/Dockerfile
+++ b/sms-notifier/Dockerfile
@@ -23,7 +23,7 @@ FROM openjdk:11-jre-slim
 WORKDIR /app
 
 # Copie o uberjar da etapa de build para a imagem final
-COPY --from=builder /app/target/uberjar/sms-notifier-prototype-0.1.0-SNAPSHOT-standalone.jar ./app.jar
+COPY --from=builder /app/target/uberjar/sms-notifier-0.1.0-SNAPSHOT-standalone.jar ./app.jar
 
 # Defina as variáveis de ambiente (serão substituídas pelas configurações do Render, se fornecidas)
 ENV WATCHER_URL="http://localhost:8080"

--- a/sms-notifier/README.md
+++ b/sms-notifier/README.md
@@ -1,17 +1,17 @@
-# SMS Notifier Prototype
+# SMS Notifier
 
 ## Visão Geral
 
-O `sms-notifier-prototype` é um microsserviço em Clojure que faz parte do **Protótipo Integrado do Sistema de Notificação (SNCT)**.
+O `sms-notifier` é um microsserviço em Clojure que faz parte do **Sistema de Notificação de Mudança de Categoria de Templates (SNCT)**.
 
-Seu propósito é validar o fluxo de notificação de ponta a ponta de forma simplificada. Ele opera da seguinte maneira:
+Seu propósito é validar o fluxo de notificação de ponta a ponta. Ele opera da seguinte maneira:
 
 1.  **Consome dados** do serviço `notification-watcher`, que detecta mudanças de categoria em templates de mensagens.
 2.  **Busca informações de contato** de clientes a partir de uma fonte de dados mockada (variável de ambiente).
 3.  **Simula o envio de notificações** por SMS, imprimindo os detalhes da notificação no console.
 4.  Garante a **idempotência**, ou seja, que a mesma notificação não seja processada repetidamente, usando um cache em memória.
 
-Este serviço **não utiliza um banco de dados**. Todo o seu estado (contatos e cache de notificações enviadas) é gerenciado em memória.
+Esta versão inicial **não utiliza um banco de dados**. Todo o seu estado (contatos e cache de notificações enviadas) é gerenciado em memória.
 
 ## Pré-requisitos
 
@@ -40,9 +40,9 @@ O serviço é configurado através de variáveis de ambiente. Você pode export�
         MOCK_CUSTOMER_DATA='{"waba_id_1": "+5511999998888", "waba_id_2": "+5521888887777"}'
         ```
 
-## Como Executar o Protótipo
+## Como Executar Localmente
 
-Para executar o protótipo completo, você precisará de dois terminais: um para o `notification-watcher` e outro para o `sms-notifier-prototype`.
+Para executar o sistema completo, você precisará de dois terminais: um para o `notification-watcher` e outro para o `sms-notifier`.
 
 ### Terminal 1: Executar o `notification-watcher`
 
@@ -51,7 +51,7 @@ Para executar o protótipo completo, você precisará de dois terminais: um para
     cd ../notification-watcher
     ```
 
-2.  **Configure as variáveis de ambiente**. Para o protótipo, é recomendado usar o modo mock da Gupshup. Crie ou edite seu arquivo `.env` ou exporte as seguintes variáveis:
+2.  **Configure as variáveis de ambiente**. Para testes, é recomendado usar o modo mock da Gupshup. Crie ou edite seu arquivo `.env` ou exporte as seguintes variáveis:
     ```sh
     export GUPSHUP_MOCK_MODE="true"
     export MOCK_CUSTOMER_MANAGER_WABA_IDS="waba_id_1,waba_id_2"

--- a/sms-notifier/project.clj
+++ b/sms-notifier/project.clj
@@ -1,5 +1,5 @@
-(defproject sms-notifier-prototype "0.1.0-SNAPSHOT"
-  :description "Prototype for the SMS Notifier service"
+(defproject sms-notifier "0.1.0-SNAPSHOT"
+  :description "SMS Notifier service"
   :url "http://example.com/FIXME"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}

--- a/sms-notifier/src/sms_notifier/core.clj
+++ b/sms-notifier/src/sms_notifier/core.clj
@@ -1,4 +1,4 @@
-(ns sms-notifier-prototype.core
+(ns sms-notifier.core
   (:require [clj-http.client :as client]
             [cheshire.core :as json]
             [environ.core :refer [env]]


### PR DESCRIPTION
As requested, this commit renames the `sms-notifier-prototype` service to its final intended name, `sms-notifier`.

This is a comprehensive renaming that includes:
- Renaming the service directory.
- Updating the project name in `project.clj`.
- Updating the namespace in `core.clj`.
- Correcting the JAR file name in the `Dockerfile`.
- Updating all references in the `README.md` documentation.

This change simplifies the project structure and aligns it with the future evolution of the service.