### PR TITLE
fix: Resolve ClassNotFoundException on deploy

### DIFF
--- a/notification-watcher/DEPLOY.md
+++ b/notification-watcher/DEPLOY.md
@@ -4,7 +4,7 @@ Este documento fornece as instruções para fazer o deploy do serviço `notifica
 
 ## Tipo de Serviço
 
-O `notification-watcher` deve ser implantado como um **Web Service** no Render, pois ele precisa expor uma porta HTTP para que o `sms-notifier-prototype` possa se conectar a ele.
+O `notification-watcher` deve ser implantado como um **Web Service** no Render, pois ele precisa expor uma porta HTTP para que o `sms-notifier` possa se conectar a ele.
 
 ## Instruções de Configuração
 
@@ -20,11 +20,11 @@ O `notification-watcher` deve ser implantado como um **Web Service** no Render, 
         *   `GUPSHUP_MOCK_MODE`:
             *   **Valor:** `true`
         *   `MOCK_CUSTOMER_MANAGER_WABA_IDS`:
-            *   **Valor:** `waba_id_1,waba_id_2` (ou os mesmos IDs que você configurou no `sms-notifier-prototype`).
+            *   **Valor:** `waba_id_1,waba_id_2` (ou os mesmos IDs que você configurou no `sms-notifier`).
         *   `PORT`:
             *   **Valor:** `8080` (O Render usa esta variável para rotear o tráfego, mesmo que o `Dockerfile` já exponha a porta).
     *   **Para produção** (no futuro):
         *   `GUPSHUP_TOKEN`: Seu token de API real da Gupshup.
         *   `CUSTOMER_MANAGER_URL`: A URL do `customer-manager-service` quando ele for desenvolvido.
 
-Após salvar, o Render irá construir a imagem Docker, implantar e iniciar o serviço. Ele receberá uma URL pública (ex: `notification-watcher.onrender.com`) que você deverá usar na configuração da variável de ambiente `WATCHER_URL` do serviço `sms-notifier-prototype`.
+Após salvar, o Render irá construir a imagem Docker, implantar e iniciar o serviço. Ele receberá uma URL pública (ex: `notification-watcher.onrender.com`) que você deverá usar na configuração da variável de ambiente `WATCHER_URL` do serviço `sms-notifier`.

--- a/sms-notifier/README.md
+++ b/sms-notifier/README.md
@@ -57,19 +57,19 @@ Para executar o sistema completo, você precisará de dois terminais: um para o 
     export MOCK_CUSTOMER_MANAGER_WABA_IDS="waba_id_1,waba_id_2"
     export PORT="8080"
     ```
-    *Nota: Os `MOCK_CUSTOMER_MANAGER_WABA_IDS` devem corresponder às chaves no `MOCK_CUSTOMER_DATA` do `sms-notifier-prototype`.*
+    *Nota: Os `MOCK_CUSTOMER_MANAGER_WABA_IDS` devem corresponder às chaves no `MOCK_CUSTOMER_DATA` do `sms-notifier`.*
 
 3.  **Execute o serviço**:
     ```sh
     lein run
     ```
-    O serviço irá iniciar e, após um breve atraso, começará a popular seus dados mockados. O endpoint `http://localhost:8080/changed-templates` estará ativo.
+    O serviço irá iniciar na porta `8080`.
 
-### Terminal 2: Executar o `sms-notifier-prototype`
+### Terminal 2: Executar o `sms-notifier`
 
 1.  **Navegue até o diretório** deste projeto:
     ```sh
-    cd ../sms-notifier-prototype
+    cd ../sms-notifier
     ```
 
 2.  **Configure as variáveis de ambiente**. Crie ou edite seu arquivo `.env` ou exporte as seguintes variáveis:
@@ -90,9 +90,9 @@ Para executar o sistema completo, você precisará de dois terminais: um para o 
 
 ### O que Esperar
 
-*   No terminal do `sms-notifier-prototype`, você verá logs indicando que ele está consultando o `notification-watcher`.
-*   Quando o `notification-watcher` tiver dados de templates alterados, o `sms-notifier-prototype` irá recebê-los.
-*   Você verá no console do `sms-notifier-prototype` uma saída formatada que **simula o envio de um SMS**, mais ou menos assim:
+*   No terminal do `sms-notifier`, você verá logs indicando que ele está consultando o `notification-watcher`.
+*   Quando o `notification-watcher` tiver dados de templates alterados, o `sms-notifier` irá recebê-los.
+*   Você verá no console do `sms-notifier` uma saída formatada que **simula o envio de um SMS**, mais ou menos assim:
 
     ```
     --------------------------------------------------

--- a/sms-notifier/project.clj
+++ b/sms-notifier/project.clj
@@ -8,7 +8,7 @@
                  [cheshire "5.11.0"]
                  [environ "1.2.0"]
                  [http-kit "2.5.3"]]
-  :main ^:skip-aot sms-notifier-prototype.core
+  :main ^:skip-aot sms-notifier.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all
                        :jvm-opts ["-Dclojure.compiler.direct-linking=true"]}})


### PR DESCRIPTION
This commit fixes a critical deployment error (`ClassNotFoundException: sms_notifier_prototype.core`) caused by an incorrect `:main` namespace definition in `project.clj` after a service rename.

Changes:
- Corrects the `:main` directive in `sms-notifier/project.clj` to point to the correct `sms-notifier.core` namespace.
- Scrubs all remaining instances of "sms-notifier-prototype" from documentation files (`README.md`, `DEPLOY.md`) to ensure consistency and prevent confusion.

This should resolve the build failure on Render and aligns the entire project with the service's final name.