### PR TITLE
docs: Add comprehensive documentation for sms-notifier

### DIFF
--- a/sms-notifier/README.md
+++ b/sms-notifier/README.md
@@ -4,45 +4,23 @@
 
 O `sms-notifier` é um microsserviço em Clojure que faz parte do **Sistema de Notificação de Mudança de Categoria de Templates (SNCT)**.
 
-Seu propósito é validar o fluxo de notificação de ponta a ponta. Ele opera da seguinte maneira:
+Seu propósito é consumir informações sobre mudanças de templates do serviço `notification-watcher`, identificar o cliente afetado e enviar uma notificação.
 
-1.  **Consome dados** do serviço `notification-watcher`, que detecta mudanças de categoria em templates de mensagens.
-2.  **Busca informações de contato** de clientes a partir de uma fonte de dados mockada (variável de ambiente).
-3.  **Simula o envio de notificações** por SMS, imprimindo os detalhes da notificação no console.
-4.  Garante a **idempotência**, ou seja, que a mesma notificação não seja processada repetidamente, usando um cache em memória.
+Esta versão inicial do serviço opera com um cache de idempotência em memória e uma fonte de dados de contato mockada (configurada por variáveis de ambiente), e simula o envio de SMS imprimindo no console.
 
-Esta versão inicial **não utiliza um banco de dados**. Todo o seu estado (contatos e cache de notificações enviadas) é gerenciado em memória.
+## Documentação Detalhada
 
-## Pré-requisitos
+Para uma compreensão aprofundada da arquitetura, funcionamento interno, configuração e pontos de evolução do serviço, consulte a seguinte documentação:
 
-*   Java (JDK 11 ou superior)
-*   [Leiningen](https://leiningen.org/)
-*   O serviço `notification-watcher` deve estar em execução.
+*   **[Documentação Técnica Detalhada (`SMS_Notifier_Status.md`)](./doc/SMS_Notifier_Status.md)**
 
-## Configuração
+Para instruções sobre como implantar este serviço na plataforma Render, consulte o guia de deploy:
 
-O serviço é configurado através de variáveis de ambiente. Você pode exportá-las no seu terminal ou criar um arquivo `.env` na raiz do projeto e usar a biblioteca `environ`.
-
-### Variáveis de Ambiente
-
-*   `WATCHER_URL`
-    *   **Descrição:** A URL base onde o serviço `notification-watcher` está escutando.
-    *   **Obrigatório:** Não
-    *   **Padrão:** `http://localhost:8080`
-    *   **Exemplo:** `WATCHER_URL="http://127.0.0.1:8080"`
-
-*   `MOCK_CUSTOMER_DATA`
-    *   **Descrição:** Uma string contendo um objeto JSON que mapeia WABA IDs (WhatsApp Business Account IDs) para números de telefone de contato.
-    *   **Obrigatório:** Sim (para que as notificações sejam "enviadas")
-    *   **Formato:** String JSON com chaves sendo os WABA IDs e valores sendo os números de telefone.
-    *   **Exemplo:**
-        ```bash
-        MOCK_CUSTOMER_DATA='{"waba_id_1": "+5511999998888", "waba_id_2": "+5521888887777"}'
-        ```
+*   **[Guia de Deploy no Render (`DEPLOY.md`)](./doc/DEPLOY.md)**
 
 ## Como Executar Localmente
 
-Para executar o sistema completo, você precisará de dois terminais: um para o `notification-watcher` e outro para o `sms-notifier`.
+Para executar o sistema completo em seu ambiente local, você precisará de dois terminais: um para o `notification-watcher` e outro para o `sms-notifier`.
 
 ### Terminal 1: Executar o `notification-watcher`
 
@@ -51,7 +29,7 @@ Para executar o sistema completo, você precisará de dois terminais: um para o 
     cd ../notification-watcher
     ```
 
-2.  **Configure as variáveis de ambiente**. Para testes, é recomendado usar o modo mock da Gupshup. Crie ou edite seu arquivo `.env` ou exporte as seguintes variáveis:
+2.  **Configure as variáveis de ambiente**. Para testes, é recomendado usar o modo mock da Gupshup:
     ```sh
     export GUPSHUP_MOCK_MODE="true"
     export MOCK_CUSTOMER_MANAGER_WABA_IDS="waba_id_1,waba_id_2"
@@ -63,7 +41,6 @@ Para executar o sistema completo, você precisará de dois terminais: um para o 
     ```sh
     lein run
     ```
-    O serviço irá iniciar na porta `8080`.
 
 ### Terminal 2: Executar o `sms-notifier`
 
@@ -72,7 +49,7 @@ Para executar o sistema completo, você precisará de dois terminais: um para o 
     cd ../sms-notifier
     ```
 
-2.  **Configure as variáveis de ambiente**. Crie ou edite seu arquivo `.env` ou exporte as seguintes variáveis:
+2.  **Configure as variáveis de ambiente**:
     ```sh
     export WATCHER_URL="http://localhost:8080"
     export MOCK_CUSTOMER_DATA='{"waba_id_1": "+5511999998888", "waba_id_2": "+5521888887777"}'
@@ -90,44 +67,4 @@ Para executar o sistema completo, você precisará de dois terminais: um para o 
 
 ### O que Esperar
 
-*   No terminal do `sms-notifier`, você verá logs indicando que ele está consultando o `notification-watcher`.
-*   Quando o `notification-watcher` tiver dados de templates alterados, o `sms-notifier` irá recebê-los.
-*   Você verá no console do `sms-notifier` uma saída formatada que **simula o envio de um SMS**, mais ou menos assim:
-
-    ```
-    --------------------------------------------------
-    SIMULANDO ENVIO DE SMS
-    PARA: +5511999998888
-    MENSAGEM: Alerta de Mudança de Categoria de Template!
-      - WABA ID: waba_id_1
-      - Template: meu_template_de_teste (template_123)
-      - Categoria Anterior: MARKETING
-      - Nova Categoria: UTILITY
-    --------------------------------------------------
-    ```
-*   Nas consultas seguintes, se a mesma notificação for detectada, você verá uma mensagem indicando que ela já foi processada e será ignorada, validando a lógica de idempotência.
-
----
-
-## Deploy no Render com Docker
-
-Para fazer o deploy deste serviço no [Render](https://render.com/) no plano gratuito, ele deve ser configurado como um **Web Service**.
-
-O serviço foi adaptado para iniciar um servidor web mínimo para satisfazer os requisitos do Render, enquanto o processo principal de notificação continua rodando em background.
-
-### Instruções de Configuração
-
-1.  **Conecte seu repositório** Git ao Render.
-2.  Crie um novo **Web Service**.
-3.  Durante a criação, o Render irá detectar o `Dockerfile` no seu repositório. Selecione esta opção para o deploy. Os comandos de build e de início já estão definidos dentro do `Dockerfile`.
-
-4.  **Porta (Port)**:
-    *   O `Dockerfile` expõe a porta `8080`. O Render detectará isso automaticamente. Certifique-se de que a configuração de porta no Render esteja definida como `8080`.
-
-5.  **Adicione as Variáveis de Ambiente** na aba "Environment" do seu serviço no Render. Estas irão sobrescrever os valores `ENV` definidos no `Dockerfile`.
-    *   `WATCHER_URL`: Aponte para a URL pública do seu serviço `notification-watcher` no Render (ex: `https://notification-watcher.onrender.com`).
-    *   `MOCK_CUSTOMER_DATA`: Cole a sua string JSON de contatos mockados. Ex: `'{"waba_id_1": "+5511999998888"}'`.
-    *   `PORT`:
-        *   **Valor:** `8080`
-
-Após salvar, o Render irá construir a imagem Docker, implantar e iniciar o serviço. A URL pública dele mostrará uma mensagem de status, e o worker de notificação estará ativo, com os logs visíveis na aba "Logs".
+Você verá logs no console do `sms-notifier` indicando as consultas ao `notification-watcher` e a simulação do envio de SMS para os contatos correspondentes.

--- a/sms-notifier/doc/DEPLOY.md
+++ b/sms-notifier/doc/DEPLOY.md
@@ -1,0 +1,26 @@
+# Deploy no Render com Docker
+
+Este documento fornece as instruções para fazer o deploy do serviço `sms-notifier` na plataforma [Render](https://render.com/), utilizando o `Dockerfile` presente no projeto.
+
+## Tipo de Serviço
+
+Para ser compatível com o plano gratuito do Render, o `sms-notifier` deve ser implantado como um **Web Service**.
+
+O serviço foi projetado para iniciar um servidor web mínimo que responde a requisições HTTP, satisfazendo os requisitos da plataforma, enquanto o processo principal de polling e notificação é executado em uma thread de background.
+
+## Instruções de Configuração
+
+1.  **Conecte seu repositório** Git ao Render.
+2.  Crie um novo **Web Service**.
+3.  Durante a criação, o Render irá detectar o `Dockerfile` no seu repositório. Selecione esta opção para o deploy. Os comandos de build (`lein uberjar`) e de início (`java -jar app.jar`) já estão definidos dentro do `Dockerfile`.
+
+4.  **Porta (Port)**:
+    *   O `Dockerfile` expõe a porta `8080`. O Render detectará isso automaticamente. Certifique-se de que a configuração de porta no Render esteja definida como `8080`.
+
+5.  **Adicione as Variáveis de Ambiente** na aba "Environment" do seu serviço no Render. Estas irão sobrescrever os valores `ENV` definidos no `Dockerfile`.
+    *   `WATCHER_URL`: Aponte para a URL pública do seu serviço `notification-watcher` no Render (ex: `https://notification-watcher.onrender.com`).
+    *   `MOCK_CUSTOMER_DATA`: Cole a sua string JSON de contatos mockados. Ex: `'{"waba_id_1": "+5511999998888"}'`.
+    *   `PORT`:
+        *   **Valor:** `8080` (O Render usa esta variável para rotear o tráfego corretamente para o contêiner).
+
+Após salvar, o Render irá construir a imagem Docker a partir do `Dockerfile`, implantar e iniciar o serviço. A URL pública dele mostrará uma mensagem de status, e o worker de notificação estará ativo. Você poderá acompanhar a atividade (consultas e simulação de envio de SMS) na aba "Logs" do serviço.

--- a/sms-notifier/doc/SMS_Notifier_Status.md
+++ b/sms-notifier/doc/SMS_Notifier_Status.md
@@ -1,0 +1,140 @@
+# Documentação Técnica Detalhada: Serviço `sms-notifier`
+
+**ID do Documento:** DOC-SN-CORE-20231029-v1.0 (Substituir pela data da efetivação)
+**Data:** 29 de Outubro de 2023 (Substituir pela data da efetivação)
+**Versão:** 1.0 (Reflete o estado inicial do serviço, adaptado para deploy como Web Service)
+**Autores:** Jules (AI Assistant), Contribuidores do Projeto
+
+## 1. Propósito
+
+Este documento fornece uma descrição técnica detalhada da implementação atual do microsserviço `sms-notifier`, com foco no seu arquivo principal `core.clj` (`sms-notifier/src/sms_notifier/core.clj`). O objetivo é servir como uma referência técnica e guia de onboarding para desenvolvedores (humanos ou IA), detalhando a arquitetura dos componentes, fluxos de dados, configuração e a lógica de negócio implementada.
+
+## 2. Visão Geral do Serviço
+
+O `sms-notifier` é um serviço em Clojure desenhado para atuar como o componente final no fluxo de notificação do sistema SNCT. Suas responsabilidades são:
+
+1.  **Consumir Dados de Mudanças:** Periodicamente, consultar o endpoint `/changed-templates` do serviço `notification-watcher` para obter a lista de templates que tiveram suas categorias alteradas.
+2.  **Mapear Contatos:** Para cada template alterado, identificar o cliente correspondente (via `wabaId`) e buscar seu número de telefone de contato em uma fonte de dados configurável (atualmente, uma variável de ambiente mockada).
+3.  **Garantir Idempotência:** Assegurar que uma notificação para uma mudança específica (mesmo template, mesma nova categoria) seja enviada apenas uma vez. Isso é feito através de um cache em memória.
+4.  **Simular o Envio de Notificações:** Formatar uma mensagem de alerta e imprimi-la no console, simulando o envio de um SMS. Na arquitetura alvo, este passo será substituído por uma chamada real a um provedor de SMS.
+5.  **Operar como Web Service:** Expor um endpoint HTTP mínimo (`/`) para ser compatível com plataformas de deploy como o Render (plano gratuito), que exigem que os serviços respondam a requisições HTTP. O trabalho principal do serviço, no entanto, é executado em um processo de background.
+
+## 3. Arquitetura Detalhada e Componentes do `core.clj`
+
+Esta seção detalha os principais componentes e a lógica contida em `sms-notifier/src/sms_notifier/core.clj`.
+
+### 3.1. Configuração e Variáveis de Ambiente
+
+O comportamento do serviço é controlado por variáveis de ambiente, permitindo flexibilidade para diferentes ambientes. A biblioteca `environ` é usada para acessá-las.
+
+*   **`WATCHER_URL`** (String)
+    *   **Propósito:** URL base do serviço `notification-watcher`, de onde os dados de templates alterados são consumidos.
+    *   **Uso no Código:** Lida pela função `fetch-and-process-templates` para construir a URL completa da API (`<WATCHER_URL>/changed-templates`).
+    *   **Obrigatoriedade:** Opcional.
+    *   **Padrão:** `"http://localhost:8080"` se não for fornecida.
+
+*   **`MOCK_CUSTOMER_DATA`** (String)
+    *   **Propósito:** Fonte de dados mockada para mapear WABA IDs a números de telefone de contato. Essencial para a operação desta versão do protótipo.
+    *   **Uso no Código:** Lida pela função `parse-customer-data` na inicialização do serviço. O conteúdo JSON é parseado e armazenado no atom `mock-customer-data`. A função `get-contact-phone` consulta este atom.
+    *   **Obrigatoriedade:** Fortemente recomendada. Sem ela, nenhuma notificação será "enviada", pois não haverá como encontrar os números de telefone.
+    *   **Formato Exemplo:** `'{"waba_id_1": "+5511999998888", "waba_id_2": "+5521888887777"}'`
+
+*   **`PORT`** (String)
+    *   **Propósito:** Especifica a porta TCP na qual o servidor web integrado (http-kit) irá escutar por requisições HTTP.
+    *   **Uso no Código:** Lida na função `-main` e passada para `server/run-server`.
+    *   **Obrigatoriedade:** Opcional.
+    *   **Padrão:** `"8080"` se não for definida.
+
+### 3.2. Estado Global (Atoms)
+
+O serviço utiliza `atom`s do Clojure para gerenciar estado mutável de forma segura e concorrente.
+
+*   **`sent-notifications-cache`** (`clojure.lang.Atom`)
+    *   **Definição:** `(atom #{})`
+    *   **Propósito:** Armazena um conjunto (`set`) de chaves únicas que representam as notificações que já foram processadas e "enviadas". Este é o mecanismo que garante a **idempotência**.
+    *   **Gerenciamento:**
+        *   **Atualização:** A função `process-notification` adiciona uma nova chave a este `set` usando `swap!` sempre que uma notificação é enviada com sucesso. A chave é uma string composta pelo ID do template e sua nova categoria (ex: `"template123_MARKETING"`).
+        *   **Consumo:** A mesma função `process-notification` verifica se a chave já existe no `set` antes de processar uma nova notificação. Se a chave existir, o processo é abortado para aquele template.
+
+*   **`mock-customer-data`** (`clojure.lang.Atom`)
+    *   **Definição:** `(atom {})`
+    *   **Propósito:** Armazena o mapa de WABA IDs para números de telefone, carregado da variável de ambiente `MOCK_CUSTOMER_DATA`.
+    *   **Gerenciamento:**
+        *   **Atualização:** A função `parse-customer-data` usa `reset!` para popular este atom no início da aplicação.
+        *   **Consumo:** A função `get-contact-phone` lê (`@`) este atom para buscar o telefone associado a um `wabaId`.
+
+### 3.3. Ponto de Entrada, Servidor Web e Loop Principal
+
+A execução do serviço é orquestrada por três funções principais.
+
+*   **`-main [& args]`**
+    *   **Propósito:** Ponto de entrada principal da aplicação (`lein run` ou `java -jar ...`).
+    *   **Funcionalidade:**
+        1.  Parseia a variável de ambiente `PORT`.
+        2.  Imprime um banner de inicialização.
+        3.  Chama `parse-customer-data` para carregar os contatos.
+        4.  Chama `start-notifier-loop!` para iniciar o processo de polling em uma thread de background.
+        5.  Inicia o servidor HTTP `http-kit` na porta configurada, usando `app-handler`. Esta chamada bloqueia a thread principal, mantendo a aplicação viva.
+
+*   **`app-handler [request]`**
+    *   **Propósito:** Handler HTTP minimalista para que o serviço se comporte como um Web Service.
+    *   **Funcionalidade:** Responde a qualquer requisição com um status `200 OK` e uma mensagem de texto simples, confirmando que o serviço está no ar.
+
+*   **`start-notifier-loop!`**
+    *   **Propósito:** Inicia o ciclo de trabalho principal do serviço em uma thread separada para não bloquear o servidor web.
+    *   **Funcionalidade:**
+        1.  Inicia um processo (`future`).
+        2.  Aguarda 30 segundos (um atraso inicial para permitir que outros serviços iniciem).
+        3.  Entra em um `loop` infinito:
+            *   Chama `fetch-and-process-templates` para executar um ciclo de verificação.
+            *   Aguarda 1 minuto (`Thread/sleep 60000`).
+            *   Chama a si mesmo (`recur`) para o próximo ciclo.
+
+### 3.4. Lógica de Negócio: Fluxo de Processamento de Notificação
+
+*   **`fetch-and-process-templates []`**
+    *   **Propósito:** Orquestra um ciclo completo de busca e processamento.
+    *   **Fluxo de Execução:**
+        1.  Obtém a URL do `notification-watcher` a partir da variável de ambiente.
+        2.  Realiza uma chamada HTTP GET para `.../changed-templates` usando `clj-http.client`.
+            *   Configura timeouts (`:conn-timeout`, `:socket-timeout`) para resiliência.
+            *   Usa `:as :json` para parsear a resposta automaticamente.
+            *   Usa `:throw-exceptions false` para tratar erros de status HTTP manualmente.
+        3.  Se a chamada for bem-sucedida (status 200) e a lista de templates não estiver vazia, itera sobre cada template e chama `process-notification`.
+        4.  Em caso de erro de conexão ou status HTTP inesperado, loga uma mensagem de erro e o ciclo termina, aguardando a próxima iteração.
+
+*   **`process-notification [template]`**
+    *   **Propósito:** Contém a lógica central para uma única notificação.
+    *   **Fluxo de Execução:**
+        1.  Extrai `wabaId`, `id` e `category` do mapa do template.
+        2.  Cria uma `notification-key` única (ex: `"template_abc_UTILITY"`).
+        3.  Verifica se a `notification-key` **já existe** no `@sent-notifications-cache`. Se sim, loga uma mensagem e para.
+        4.  Se a chave não existe, chama `get-contact-phone` para buscar o número do contato.
+        5.  Se o contato for encontrado:
+            *   Formata e imprime a mensagem de simulação de SMS no console.
+            *   Adiciona a `notification-key` ao `sent-notifications-cache` usando `swap!`.
+        6.  Se o contato não for encontrado, loga um aviso.
+
+## 4. Considerações para Evolução Futura
+
+Esta implementação inicial como protótipo é funcional, mas foi projetada com vários pontos de evolução em mente para se alinhar com a **Arquitetura Alvo**.
+
+1.  **Persistência de Dados (Idempotência):**
+    *   **Situação Atual:** O cache de idempotência (`sent-notifications-cache`) é um `atom` em memória. Se o serviço reiniciar, ele perde todo o histórico e pode reenviar notificações.
+    *   **Próximo Passo:** Substituir o `atom` por uma tabela em um banco de dados (ex: CockroachDB, PostgreSQL). A função `process-notification` faria um `SELECT` para verificar a existência da notificação e um `INSERT` após o envio.
+
+2.  **Integração com Provedor de SMS Real:**
+    *   **Situação Atual:** O envio de notificações é simulado com `println`.
+    *   **Próximo Passo:** Integrar uma biblioteca cliente para um provedor de SMS (ex: Twilio, Vonage). A chamada a `println` seria substituída por uma chamada de API a este provedor.
+
+3.  **Fonte de Dados de Contato:**
+    *   **Situação Atual:** Os dados de contato são mockados em uma variável de ambiente.
+    *   **Próximo Passo:** Substituir a chamada a `get-contact-phone` por uma chamada de API ao `customer-manager-service`, que se tornará a fonte da verdade para os dados dos clientes.
+
+4.  **Logging Estruturado e Monitoramento:**
+    *   **Situação Atual:** O logging é feito com `println`.
+    *   **Próximo Passo:** Implementar uma biblioteca de logging estruturado (ex: `tools.logging` com SLF4J/Logback) para permitir a coleta e análise de logs em produção. Adicionar métricas de monitoramento (ex: número de notificações enviadas, erros de API).
+
+5.  **Mecanismo de Retentativas (Retry):**
+    *   **Situação Atual:** Se a chamada ao `notification-watcher` falhar, ela só será tentada novamente no próximo ciclo (1 minuto depois).
+    *   **Próximo Passo:** Implementar uma lógica de retentativa com backoff exponencial (ex: usando a biblioteca `diehard`) para tornar a comunicação entre serviços mais resiliente a falhas transitórias.


### PR DESCRIPTION
This commit introduces a new, detailed documentation structure for the `sms-notifier` service, following the context engineering pattern established by `notification-watcher`.

Changes:
- Creates a `doc/` directory within `sms-notifier`.
- Adds `SMS_Notifier_Status.md`, a detailed technical document covering the service's architecture, data flow, configuration, and evolution points, aimed at both developers and AI.
- Adds `DEPLOY.md` with specific instructions for deploying to Render.
- Refactors the main `README.md` to be a concise entry point, linking to the detailed documentation in the `doc/` folder.

This provides a robust and clear documentation framework for the service.