### PR TITLE
Docs: Document anti-spam feature

### DIFF
--- a/sms-notifier/README.md
+++ b/sms-notifier/README.md
@@ -12,6 +12,7 @@ Sua função é consumir alertas sobre mudanças de categoria de templates do se
   * **Envio de Notificações por SMS**: Integra-se com uma API de SMS externa para enviar alertas formatados aos contatos dos clientes.
   * **Idempotência com Persistência**: Utiliza um banco de dados (como PostgreSQL) para registrar todas as notificações já enviadas. Isso previne o envio de alertas duplicados, mesmo que o serviço seja reiniciado.
   * **Resiliência (Circuit Breaker)**: Implementa um padrão de Circuit Breaker que interrompe as operações com o banco de dados em caso de falhas repetidas, evitando sobrecarga e permitindo a recuperação do sistema.
+  * **Controle de Spam**: Para evitar o envio excessivo de mensagens, o sistema limita o número de notificações para um mesmo contato durante um único ciclo de processamento.
   * **Configuração Flexível**: O comportamento do serviço é totalmente controlado por variáveis de ambiente, facilitando o deploy em diferentes ambientes.
 
 ## Documentação Detalhada

--- a/sms-notifier/doc/prototipo/relatorio_tecnico_de_todo_prototipo
+++ b/sms-notifier/doc/prototipo/relatorio_tecnico_de_todo_prototipo
@@ -82,6 +82,15 @@ O sistema é composto por um microsserviço de monitoramento, um microsserviço 
         v.  **Envio:** O canal é responsável por enviar a notificação. Ele é inteligente o suficiente para lidar com múltiplos valores (ex: um array de emails no campo `:email` do contato).
         vi. **Persistência:** Após todos os contatos para aquele template serem processados, a `notification-key` é salva no banco de dados **uma única vez**.
 
+### 3.4. Mecanismo de Controle Anti-Spam
+
+Para garantir o uso consciente dos recursos de notificação e prevenir o envio massivo de mensagens para um mesmo destinatário em um curto período, o serviço implementa um mecanismo de controle de spam a nível de memória.
+
+*   **Funcionamento:** Durante cada ciclo de `fetch-and-process-templates`, o sistema mantém um contador para cada contato individual (ex: número de telefone ou email).
+*   **Limite:** Por padrão, há um limite de **5 notificações** por contato (`SPAM_LIMIT`).
+*   **Ação:** Se o número de tentativas de envio para um mesmo contato exceder este limite dentro do mesmo ciclo, as notificações subsequentes para aquele contato são bloqueadas e um alerta é registrado no log do sistema.
+*   **Escopo:** É importante notar que este contador é reiniciado a cada novo ciclo de busca por templates, ou seja, ele não é persistido entre as execuções do worker. Seu objetivo é conter anomalias ou bugs que poderiam levar a um loop de envio dentro de uma única execução.
+
 -----
 
 ## 4\. Pilha Tecnológica (Stack)


### PR DESCRIPTION
Adds documentation for the existing in-memory anti-spam mechanism.

The feature limits the number of notifications sent to a single contact during one processing cycle to 5, preventing excessive messaging in case of anomalies.

This information has been added to:
- `README.md`: A brief mention in the main features list.
- `doc/prototipo/relatorio_tecnico_de_todo_prototipo`: A detailed section explaining its operation, limit, and scope.